### PR TITLE
Change org namespace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,16 @@ val supportedScalaVersions = List(scala213,scala212)
 
 inScope(Scope.GlobalScope)(
   List(
-    organization := "us.oyanglul",
+    organization := "org.http4s",
     licenses := Seq("Apache License 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-    homepage := Some(url("https://github.com/jcouyang/http4s-finagle")),
+    homepage := Some(url("https://github.com/http4s/http4s-finagle")),
     developers := List(
       Developer("jcouyang", "Jichao Ouyang", "oyanglulu@gmail.com", url("https://github.com/jcouyang"))
     ),
     scmInfo := Some(
       ScmInfo(
-        url("https://github.com/jcouyang/http4s-finagle"),
-        "scm:git@github.com:jcouyang/http4s-finagle.git"
+        url("https://github.com/http4s/http4s-finagle"),
+        "scm:git@github.com:http4s/http4s-finagle.git"
       )
     ),
     pgpPublicRing := file(".") / ".gnupg" / "pubring.asc",


### PR DESCRIPTION
Hi @rossabaker 
I might need you help to enable the auto release to sonatype in `org.http4s` namespace, this will require 5 creds ready in Github Secret

![image](https://user-images.githubusercontent.com/1235045/81499405-c7416b80-930e-11ea-8188-9896ba595618.png)

Here is the config to read them in workflow
https://github.com/http4s/http4s-finagle/blob/6b0709c0629a91e9bf59827706eea651c2f14abf/.github/workflows/release.yml#L33-L37

`GPG_SEC` is GPG private key in base64
`GPG_PUB` is GPG public key in base64