### PR TITLE
Upgrade to http4s 0.23.21

### DIFF
--- a/app.dhall
+++ b/app.dhall
@@ -1,6 +1,6 @@
-let http4sVersion = "0.22.15"
+let http4sVersion = "0.23.21"
 
-let finagleVersion = "22.3.0"
+let finagleVersion = "22.12.0"
 
 in  { version = "${http4sVersion}-${finagleVersion}"
     , http4sVersion

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
-import Dependencies._
-
 val scala213 = "2.13.8"
 val scala212 = "2.12.15"
 val dotty = "3.0.2"
 
-val Http4sVersion = "0.22.15"
-val FinagleVersion = "22.3.0"
+val Http4sVersion = "0.23.21"
+val FinagleVersion = "22.12.0"
 val supportedScalaVersions = List(scala213,scala212,dotty)
 
 inScope(Scope.GlobalScope)(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,0 @@
-import sbt._
-
-object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
-}

--- a/src/test/scala/org/http4s/finagle/FinagleSpec.scala
+++ b/src/test/scala/org/http4s/finagle/FinagleSpec.scala
@@ -17,8 +17,10 @@ import org.scalacheck.Prop._
 import com.twitter.finagle.http.RequestBuilder
 import cats.effect.unsafe.implicits.{global => runtime}
 
+import scala.concurrent.ExecutionContext
+
 class FinagleSpec extends munit.FunSuite with munit.ScalaCheckSuite {
-  implicit val ec = runtime.compute
+  implicit val ec: ExecutionContext = runtime.compute
   val service = Finagle.mkService{HttpRoutes.of[IO] {
     case req @ _ -> Root / "echo" => Ok(req.as[String])
     case GET -> Root / "simple" => Ok("simple path")


### PR DESCRIPTION
An attempt to upgrade the library to support the current stable http4s version, which uses cats-effect 3.
This changes the `mkService` signature that now expects implicit ExecutionContext and return value is now `Resource[F, Service[Req, Resp]]` due to the use of `Dispatcher`, which is a [recommended ](https://typelevel.org/cats-effect/docs/migration-guide#effect-concurrenteffect-synceffect) way of executing effects in this case. 
This is a breaking change, but without it you'd have to do something ugly to run the effect, e.g.
`...asInstanceOf[IO].unsafeRunSync()`

I haven't updated the documentation, but the clients will be required to treat the `mkService` as a Resource just as any other resource.

An alternative would be for clients to create a Dispatcher resource and supply it to the `mkService` directly.

- Fix cats-effect 3 breaking changes
- Fix tests
- Some minor cleanup